### PR TITLE
[Feat] 로그인 api 연결

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:name=".NuvoApp"
+        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/snacks/nuvo/NuvoNavHost.kt
+++ b/app/src/main/java/com/snacks/nuvo/NuvoNavHost.kt
@@ -56,7 +56,7 @@ fun NuvoNavHost(appState: NuvoAppState) {
     ) { paddingValues ->
         NavHost(
             navController = navController,
-            startDestination = Routes.Home.ROUTE,
+            startDestination = Routes.Login.LOGIN,
             modifier = Modifier.padding(paddingValues),
         ) {
             loginGraph(appState)

--- a/app/src/main/java/com/snacks/nuvo/TempAuth.kt
+++ b/app/src/main/java/com/snacks/nuvo/TempAuth.kt
@@ -1,0 +1,14 @@
+package com.snacks.nuvo
+
+object TempAuthManager {
+
+    private var accessToken: String? = null
+
+    fun issueAndSaveToken(token: String) {
+        this.accessToken = token
+    }
+
+    fun getAccessToken(): String? {
+        return accessToken
+    }
+}

--- a/app/src/main/java/com/snacks/nuvo/network/model/request/RegisterRequest.kt
+++ b/app/src/main/java/com/snacks/nuvo/network/model/request/RegisterRequest.kt
@@ -3,8 +3,7 @@ package com.snacks.nuvo.network.model.request
 import com.google.gson.annotations.SerializedName
 
 data class RegisterRequest(
-    @SerializedName("nickname")
-    val nickname: String,
+
     @SerializedName("password")
     val password: String,
     @SerializedName("username")

--- a/app/src/main/java/com/snacks/nuvo/ui/login/LoginNavigation.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/LoginNavigation.kt
@@ -2,7 +2,9 @@ package com.snacks.nuvo.ui.login
 
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.snacks.nuvo.NuvoAppState
 import com.snacks.nuvo.Routes
 import com.snacks.nuvo.ui.login.login.LoginScreen
@@ -37,10 +39,13 @@ fun NavGraphBuilder.loginGraph(
     }
 
     composable(
-        route = Routes.Login.WELCOME
+        route = "${Routes.Login.WELCOME}/{nickname}",
+        arguments = listOf(navArgument("nickname") { type = NavType.StringType })
     ) {
+        val nickname = it.arguments?.getString("nickname") ?: ""
         WelcomScreen(
-            appState = appState
+            appState = appState,
+            nickname = nickname
         )
     }
 }

--- a/app/src/main/java/com/snacks/nuvo/ui/login/WelcomScreen.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/WelcomScreen.kt
@@ -34,7 +34,7 @@ import com.snacks.nuvo.ui.theme.NuvoTheme
 import kotlinx.coroutines.delay
 
 @Composable
-internal fun WelcomScreen(appState: NuvoAppState? = null ) {
+internal fun WelcomScreen(appState: NuvoAppState? = null, nickname: String ) {
     LaunchedEffect(Unit) {
         delay(3000) // 3초 대기
         appState?.navigate(Routes.Home.ROUTE) // 원하는 라우트로 이동
@@ -78,7 +78,7 @@ internal fun WelcomScreen(appState: NuvoAppState? = null ) {
                         color = NuvoTheme.colors.white
                     )
                     ){
-                        append("도도도")
+                        append(nickname)
                     }
                     withStyle(style = SpanStyle(
                         fontFamily = Inter,
@@ -118,5 +118,5 @@ internal fun WelcomScreen(appState: NuvoAppState? = null ) {
 @Composable
 fun a (){
 
-    WelcomScreen()
+    WelcomScreen(nickname = "도도도")
 }

--- a/app/src/main/java/com/snacks/nuvo/ui/login/components/LoginForm.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/components/LoginForm.kt
@@ -14,9 +14,9 @@ import com.snacks.nuvo.ui.theme.NuvoTheme
 @Composable
 internal fun LoginForm(
     modifier: Modifier = Modifier,
-    idText: String,
+    usernameText: String,
     passwordText: String,
-    onIdTextChange: (String) -> Unit,
+    onUsernameTextChange: (String) -> Unit,
     onPasswordTextChange: (String) -> Unit,
 ) {
     Column(
@@ -28,7 +28,7 @@ internal fun LoginForm(
                 .fillMaxWidth()
                 .padding(horizontal = 36.dp)
                 .height(60.dp),
-            value = idText,
+            value = usernameText,
             shape = RoundedCornerShape(10.dp),
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor = NuvoTheme.colors.mainGreen,
@@ -37,8 +37,8 @@ internal fun LoginForm(
                 focusedLabelColor = NuvoTheme.colors.mainGreen,
                 unfocusedLabelColor = NuvoTheme.colors.gray5
             ),
-            onValueChange = onIdTextChange,
-            label = { Text("아이디") }
+            onValueChange = onUsernameTextChange,
+            label = { Text("닉네임") }
         )
 
         Spacer(Modifier.height(10.dp))

--- a/app/src/main/java/com/snacks/nuvo/ui/login/components/RegisterForm.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/components/RegisterForm.kt
@@ -10,14 +10,15 @@ import com.snacks.nuvo.ui.theme.NuvoTheme
 internal fun RegisterForm(
     modifier: Modifier = Modifier,
     nicknameText: String,
-    idText: String,
+    emailText: String,
     passwordText: String,
     confirmPasswordText: String,
     onNicknameChange: (String) -> Unit,
-    onIdChange: (String) -> Unit,
+    onEmailChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,
     onConfirmPasswordChange: (String) -> Unit,
     showPasswordMismatchError: Boolean,
+    showPasswordLengthError: Boolean,
 ) {
     Column(
         modifier = modifier.padding(horizontal = 38.dp)
@@ -34,10 +35,13 @@ internal fun RegisterForm(
         Spacer(Modifier.height(36.dp))
 
         RegisterInputField(
-            label = "아이디",
-            placeholder = "아이디 입력",
-            value = idText,
-            onValueChange = onIdChange
+            label = "이메일",
+            placeholder = "이메일 입력",
+            value = emailText,
+            onValueChange = onEmailChange ,
+            errorMessage = if (emailText.isNotEmpty() && !emailText.contains("@")) {
+                "올바른 이메일 주소를 입력해주세요."
+            } else null
         )
 
         Spacer(Modifier.height(36.dp))
@@ -47,7 +51,8 @@ internal fun RegisterForm(
             placeholder = "비밀번호 입력",
             value = passwordText,
             onValueChange = onPasswordChange,
-            isPassword = true
+            isPassword = true,
+            errorMessage = if (showPasswordLengthError) "비밀번호는 8자 이상이어야 합니다." else null
         )
 
         Spacer(Modifier.height(12.dp))
@@ -58,7 +63,7 @@ internal fun RegisterForm(
             value = confirmPasswordText,
             onValueChange = onConfirmPasswordChange,
             isPassword = true,
-            isError = showPasswordMismatchError,
+            errorMessage = if (showPasswordMismatchError) "비밀번호가 일치하지 않습니다." else null
         )
     }
 }

--- a/app/src/main/java/com/snacks/nuvo/ui/login/components/RegisterInputField.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/components/RegisterInputField.kt
@@ -20,7 +20,7 @@ internal fun RegisterInputField(
     value: String,
     onValueChange: (String) -> Unit,
     isPassword: Boolean = false,
-    isError: Boolean = false
+    errorMessage: String? = null
 ) {
     Column(modifier = modifier) {
         Text(
@@ -39,8 +39,8 @@ internal fun RegisterInputField(
             value = value,
             shape = RoundedCornerShape(10.dp),
             colors = OutlinedTextFieldDefaults.colors(
-                focusedBorderColor = if (isError) Color(0xFFFF0E0E) else NuvoTheme.colors.mainGreen,
-                unfocusedBorderColor = if (isError) Color(0xFFFF0E0E) else NuvoTheme.colors.gray3,
+                focusedBorderColor = if (errorMessage != null) Color(0xFFFF0E0E) else NuvoTheme.colors.mainGreen,
+                unfocusedBorderColor = if (errorMessage != null) Color(0xFFFF0E0E) else NuvoTheme.colors.gray3,
                 cursorColor = NuvoTheme.colors.mainGreen,
                 focusedLabelColor = NuvoTheme.colors.mainGreen,
                 unfocusedLabelColor = NuvoTheme.colors.gray5
@@ -48,11 +48,11 @@ internal fun RegisterInputField(
             onValueChange = onValueChange,
             label = { Text(placeholder) },
             visualTransformation = if (isPassword) PasswordVisualTransformation() else VisualTransformation.None,
-            isError = isError
+            isError = errorMessage != null
         )
-        if(isError){
+        if(errorMessage != null){
             Text(
-                text = "비밀번호가 일치하지 않습니다",
+                text = errorMessage,
                 color = Color(0xFFFF0E0E),
                 style = NuvoTheme.typography.interRegular15,
                 modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp)

--- a/app/src/main/java/com/snacks/nuvo/ui/login/components/RegisterTopBar.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/components/RegisterTopBar.kt
@@ -10,7 +10,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.snacks.nuvo.R
 import com.snacks.nuvo.ui.theme.NuvoTheme
 
 @Composable
@@ -29,7 +31,7 @@ internal fun RegisterTopBar(
             modifier = Modifier.size(48.dp)
         ) {
             Icon(
-                imageVector = Icons.Default.KeyboardArrowLeft,
+                painter = painterResource(R.drawable.ic_back,),
                 contentDescription = "뒤로가기",
                 tint = NuvoTheme.colors.gray6
             )

--- a/app/src/main/java/com/snacks/nuvo/ui/login/login/AuthModule.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/login/AuthModule.kt
@@ -1,0 +1,55 @@
+package com.snacks.nuvo.ui.login.login
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AuthModule {
+
+    private const val BASE_URL = "http://core-artsw.duckdns.org/"
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(): OkHttpClient {
+        val loggingInterceptor = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+        return OkHttpClient.Builder()
+            .addInterceptor(loggingInterceptor)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideAuthService(retrofit: Retrofit): AuthService {
+        return retrofit.create(AuthService::class.java)
+    }
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AuthRepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindAuthRepository(authRepositoryImpl: AuthRepositoryImpl): AuthRepository
+}

--- a/app/src/main/java/com/snacks/nuvo/ui/login/login/AuthRepository.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/login/AuthRepository.kt
@@ -1,0 +1,34 @@
+package com.snacks.nuvo.ui.login.login
+
+import com.snacks.nuvo.network.model.request.LoginRequest
+import com.snacks.nuvo.network.model.request.RegisterRequest
+import com.snacks.nuvo.network.model.response.LoginResponse
+import com.snacks.nuvo.network.model.response.RegisterResponse
+import javax.inject.Inject
+
+interface AuthRepository {
+    suspend fun login(loginRequest: LoginRequest): Result<LoginResponse>
+    suspend fun register(registerRequest: RegisterRequest): Result<RegisterResponse>
+}
+
+class AuthRepositoryImpl @Inject constructor(
+    private val authService: AuthService
+) : AuthRepository {
+    override suspend fun login(loginRequest: LoginRequest): Result<LoginResponse> {
+        return try {
+            val response = authService.login(loginRequest)
+            Result.success(response)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun register(registerRequest: RegisterRequest): Result<RegisterResponse> {
+        return try {
+            val response = authService.register(registerRequest)
+            Result.success(response)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/app/src/main/java/com/snacks/nuvo/ui/login/login/AuthService.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/login/AuthService.kt
@@ -1,0 +1,16 @@
+package com.snacks.nuvo.ui.login.login
+
+import com.snacks.nuvo.network.model.request.LoginRequest
+import com.snacks.nuvo.network.model.request.RegisterRequest
+import com.snacks.nuvo.network.model.response.LoginResponse
+import com.snacks.nuvo.network.model.response.RegisterResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthService {
+    @POST("auth/login")
+    suspend fun login(@Body request: LoginRequest): LoginResponse
+
+    @POST("auth/register")
+    suspend fun register(@Body request: RegisterRequest): RegisterResponse
+}

--- a/app/src/main/java/com/snacks/nuvo/ui/login/login/LoginScreen.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/login/LoginScreen.kt
@@ -35,9 +35,9 @@ internal fun LoginScreen(
             Spacer(Modifier.height(48.dp))
 
             LoginForm(
-                idText = uiState.idText,
+                usernameText = uiState.usernameText,
                 passwordText = uiState.passwordText,
-                onIdTextChange = viewModel::updateIdText,
+                onUsernameTextChange = viewModel::updateUsernameText,
                 onPasswordTextChange = viewModel::updatePasswordText
             )
 
@@ -46,8 +46,8 @@ internal fun LoginScreen(
             AuthButton(
                 isEnabled = uiState.isLoginButtonEnabled,
                 onClick = {
-                    viewModel.login {
-                        appState.navigate(Routes.Home.ROUTE)
+                    viewModel.login { nickname ->
+                        appState.navigate("${Routes.Login.WELCOME}/$nickname")
                     }
                 },
                 label = "로그인"

--- a/app/src/main/java/com/snacks/nuvo/ui/login/login/LoginUiState.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/login/LoginUiState.kt
@@ -2,10 +2,11 @@ package com.snacks.nuvo.ui.login.login
 
 
 data class LoginUiState(
-    val idText: String = "",
+    val usernameText: String = "",
     val passwordText: String = "",
     val isLoading: Boolean = false,
-    val isLoginButtonEnabled: Boolean = false
+    val isLoginButtonEnabled: Boolean = false,
+    val error: String? = null
 ) {
     companion object {
         fun create() = LoginUiState()

--- a/app/src/main/java/com/snacks/nuvo/ui/login/login/LoginViewModel.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/login/LoginViewModel.kt
@@ -1,24 +1,29 @@
 package com.snacks.nuvo.ui.login.login
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.snacks.nuvo.TempAuthManager
+import com.snacks.nuvo.network.model.request.LoginRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class LoginViewModel @Inject constructor() : ViewModel() {
+class LoginViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(LoginUiState.create())
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
 
-    fun updateIdText(id: String) {
+    fun updateUsernameText(username: String) {
         val currentState = _uiState.value
         _uiState.value = currentState.copy(
-            idText = id,
-            isLoginButtonEnabled = id.isNotEmpty() && currentState.passwordText.isNotEmpty()
+            usernameText = username,
+            isLoginButtonEnabled = username.isNotEmpty() && currentState.passwordText.isNotEmpty()
         )
     }
 
@@ -26,19 +31,34 @@ class LoginViewModel @Inject constructor() : ViewModel() {
         val currentState = _uiState.value
         _uiState.value = currentState.copy(
             passwordText = password,
-            isLoginButtonEnabled = currentState.idText.isNotEmpty() && password.isNotEmpty()
+            isLoginButtonEnabled = currentState.usernameText.isNotEmpty() && password.isNotEmpty()
         )
     }
 
-    fun login(onSuccess: () -> Unit) {
+    fun login(onSuccess: (String) -> Unit) {
         val currentState = _uiState.value
         if (currentState.isLoginButtonEnabled) {
-            _uiState.value = currentState.copy(isLoading = true)
+            viewModelScope.launch {
+                _uiState.value = currentState.copy(isLoading = true, error = null)
 
-            // 실제 로그인 로직을 여기에 구현
-            // 예시: 로그인 성공 시
-            _uiState.value = currentState.copy(isLoading = false)
-            onSuccess()
+                val result = authRepository.login(
+                    LoginRequest(
+                        username = currentState.usernameText,
+                        password = currentState.passwordText
+                    )
+                )
+
+                result.onSuccess { response ->
+                    TempAuthManager.issueAndSaveToken(response.accessToken)
+                    _uiState.value = _uiState.value.copy(isLoading = false)
+                    onSuccess(currentState.usernameText)
+                }.onFailure {
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        error = it.message ?: "An unknown error occurred"
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/snacks/nuvo/ui/login/register/RegisterUiState.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/register/RegisterUiState.kt
@@ -2,14 +2,17 @@ package com.snacks.nuvo.ui.login.register
 
 data class RegisterUiState(
     val nicknameText: String = "",
-    val idText: String = "",
+    val emailText: String = "",
     val passwordText: String = "",
     val confirmPasswordText: String = "",
     val isLoading: Boolean = false,
     val isConfirmPasswordValid: Boolean = false,
+    val isPasswordLengthValid: Boolean = false,
     val isAllFieldsFilled: Boolean = false,
     val canRegister: Boolean = false,
-    val showPasswordMismatchError: Boolean = false
+    val showPasswordMismatchError: Boolean = false,
+    val showPasswordLengthError: Boolean = false,
+    val error: String? = null
 ) {
     companion object {
         fun create() = RegisterUiState()

--- a/app/src/main/java/com/snacks/nuvo/ui/login/register/registerScreen.kt
+++ b/app/src/main/java/com/snacks/nuvo/ui/login/register/registerScreen.kt
@@ -16,7 +16,7 @@ import com.snacks.nuvo.ui.theme.NuvoTheme
 internal fun RegisterScreen(
     appState: NuvoAppState,
     onBackClick: () -> Unit = {},
-    viewModel: RegisterViewModel = RegisterViewModel()
+    viewModel: RegisterViewModel
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
@@ -34,14 +34,15 @@ internal fun RegisterScreen(
 
             RegisterForm(
                 nicknameText = uiState.nicknameText,
-                idText = uiState.idText,
+                emailText = uiState.emailText,
                 passwordText = uiState.passwordText,
                 confirmPasswordText = uiState.confirmPasswordText,
                 onNicknameChange = viewModel::updateNicknameText,
-                onIdChange = viewModel::updateIdText,
+                onEmailChange = viewModel::updateEmailText,
                 onPasswordChange = viewModel::updatePasswordText,
                 onConfirmPasswordChange = viewModel::updateConfirmPasswordText,
                 showPasswordMismatchError = uiState.showPasswordMismatchError,
+                showPasswordLengthError = uiState.showPasswordLengthError,
             )
 
             Spacer(Modifier.height(60.dp))
@@ -50,7 +51,8 @@ internal fun RegisterScreen(
                 isEnabled = uiState.canRegister,
                 onClick = {
                     viewModel.register {
-                        appState.navigate(Routes.Login.WELCOME)
+                            nickname ->
+                        appState.navigate("${Routes.Login.WELCOME}/$nickname")
                     }
                 },
                 label = "회원가입"


### PR DESCRIPTION
## ✨ 작업 내용

> 이번 PR에서 작업한 내용을 설명해주세요

- 로그인 회원기입 api 구현했습니다
- 서버에서 로그인할때 아이디가 아니라 username을 받길래 로그인화면 조금 수정했습니다
- 서버에서 회원가입할때 아이디가 아니라 email을 받길래 회원가입화면 조금 수정했습니다
- 서버에서 회원가입할떄 인증로직이 있어서 클라이언트에서도 추가했습니다
- 로그인,회원가입하고 나온 accessToken을 TempAuthManager에 단순하게 그냥 저장해놨습니다
- 


<br> 

## 💫 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이나 질문이 있다면 작성해주세요

- 늦어서 죄송합니다,,,
- 
